### PR TITLE
pokemonListの重複を省いた

### DIFF
--- a/app/src/main/java/com/example/recyclerviewapp/MainActivity.kt
+++ b/app/src/main/java/com/example/recyclerviewapp/MainActivity.kt
@@ -3,7 +3,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -11,11 +10,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
 class MainActivity : AppCompatActivity() {
-    lateinit var recyclerView: RecyclerView
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+    /**
+     * 表示させるポケモンの文字列のリスト
+     */
+    fun createPokemonList(): List<String>{
         val pokemonList = listOf(
             "ピカチュウ",
             "カイリュー",
@@ -33,39 +31,28 @@ class MainActivity : AppCompatActivity() {
             "ガラガラ",
             "フシギダネ"
         )
+        return pokemonList
+    }
+    lateinit var recyclerView: RecyclerView
+    val pokemonList = createPokemonList()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
         recyclerView = findViewById(R.id.recyclerView)
         recyclerView.layoutManager = LinearLayoutManager(this)
         val adapter = MyRecyclerViewAdapter(pokemonList)
         recyclerView.adapter = adapter
     }
-    class ItemClickListener :View.OnClickListener {
-        override fun onClick(view: View){
-            val pokemonName = view.findViewById<TextView>(R.id.title)
-            val pokemonName1 = pokemonName.text.toString()
-            Toast.makeText(view.context, pokemonName1, Toast.LENGTH_LONG).show()
-        }
-    }
+
+    /**
+     *
+     */
     class MyViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val positionText: TextView
         val titleText: TextView
         val pokemonButton: TextView
-        val pokemonList = listOf(
-            "ピカチュウ",
-            "カイリュー",
-            "ヤドラン",
-            "ピジョン",
-            "コダック",
-            "コラッタ",
-            "ズバット",
-            "ギャロップ",
-            "サンダース",
-            "メノクラゲ",
-            "パウワウ",
-            "カラカラ",
-            "タマタマ",
-            "ガラガラ",
-            "フシギダネ"
-        )
+       // val pokemonList = createPokemonList();
+
         init {
             positionText = itemView.findViewById(R.id.position)
             titleText = itemView.findViewById(R.id.title)
@@ -73,15 +60,20 @@ class MainActivity : AppCompatActivity() {
             pokemonButton.setOnClickListener{v: View ->
                 val position: Int =adapterPosition
                 val num: Int = position.toInt()
-                Toast.makeText(pokemonButton.context, pokemonList[num], Toast.LENGTH_LONG).show()
+                //Toast.makeText(pokemonButton.context, pokemonList[num], Toast.LENGTH_LONG).show()
+                Toast.makeText(pokemonButton.context, titleText.text.toString(), Toast.LENGTH_LONG).show()
+
             }
         }
     }
+
+    /**
+     *
+     */
     class MyRecyclerViewAdapter(val list: List<String>) : RecyclerView.Adapter<MyViewHolder>() {
-        //private var listener: View.OnClickListener? = null
+
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyViewHolder {
             val itemView = LayoutInflater.from(parent.context).inflate(R.layout.item_recycler_view, parent, false)
-            itemView.findViewById<Button>(R.id.pokemon_button).setOnClickListener(ItemClickListener())
             return MyViewHolder(itemView)
         }
         override fun onBindViewHolder(holder: MyViewHolder, position: Int) {


### PR DESCRIPTION
最初以下のことをしたが失敗
ポケモンの文字列のリストを返すメソッドを定義し、
ViewHolderクラス内でそのメソッドを使おうとしたが、失敗。

その後以下のことをしたら成功した。
Toast.makeText(pokemonButton.context, titleText.text.toString(), Toast.LENGTH_LONG).show()

